### PR TITLE
Api provides the ability for a user(landlord) to see their listings

### DIFF
--- a/app/controllers/api/v1/account/listings_controller.rb
+++ b/app/controllers/api/v1/account/listings_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::Account::ListingsController < ApplicationController
+  before_action :authenticate_user!
+  
+  def index
+    listings = current_user.listings
+    render json: listings, each_serializer: ListingIndexSerializer
+  end
+end

--- a/app/controllers/api/v1/biddings_controller.rb
+++ b/app/controllers/api/v1/biddings_controller.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 class Api::V1::BiddingsController < ApplicationController
   before_action :authenticate_user!, only: [:create]
   def create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
       resources  :listings, only: [:index, :show, :create], constraints: {format: 'json'}
       resources :subscriptions, only: [:create], constraints: {format: 'json'}
       resources :biddings, only: [:create]
+
+      namespace :account do
+        resources :listings, only: [:index], constraints: {format: 'json'}
+      end
     end
   end  
 end

--- a/spec/requests/api/v1/account/account_index_spec.rb
+++ b/spec/requests/api/v1/account/account_index_spec.rb
@@ -1,7 +1,11 @@
 RSpec.describe "GET '/api/v1/account/listings" do
   let!(:landlord) { create(:user)}
+  let!(:subscriber) { create(:user)}
 
-  let!(:listing) { 2.times { create(:listing, landlord_id: landlord.id) } }
+  let!(:listing_1) { create(:listing, lead: 'The first lead', scene: 'indoor', landlord_id: landlord.id) }
+  let!(:listing_2) { create(:listing, lead: 'The second lead', scene: 'indoor', landlord_id: subscriber.id) }
+  let!(:listing_3) { create(:listing, lead: 'The third lead', scene: 'indoor', landlord_id: subscriber.id) }
+  let!(:listing_4) { create(:listing, lead: 'The fourth lead', scene: 'outdoor', landlord_id: landlord.id) }
 
   describe 'landlord successfully get published listings' do
     let(:landlord_credentials) { landlord.create_new_auth_token }
@@ -21,11 +25,26 @@ RSpec.describe "GET '/api/v1/account/listings" do
     end
 
     it 'should return landlord listings with lead' do
-      expect(response_json["listings"].first["lead"]).to eq 'vacant'
+      expect(response_json["listings"].first["lead"]).to eq 'The first lead'
     end
 
     it 'should return landlord listings with lead' do
-      expect(response_json["listings"].first["scene"]).to eq 'indoor'
+      expect(response_json["listings"].last["scene"]).to eq 'outdoor'
+    end
+  end
+
+
+  describe 'non-registered users unsuccessfully gets listings' do
+    before do
+      get '/api/v1/account/listings'
+    end
+
+    it "should return a 401 status" do 
+      expect(response).to have_http_status 401
+    end
+
+    it "is expected to return error message" do 
+      expect(response_json['errors'].first).to eq 'You need to sign in or sign up before continuing.'
     end
   end
 end

--- a/spec/requests/api/v1/account/account_index_spec.rb
+++ b/spec/requests/api/v1/account/account_index_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe "GET '/api/v1/account/listings" do
+  let!(:landlord) { create(:user)}
+
+  let!(:listing) { 2.times { create(:listing, landlord_id: landlord.id) } }
+
+  describe 'landlord successfully get published listings' do
+    let(:landlord_credentials) { landlord.create_new_auth_token }
+    let(:landlord_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(landlord_credentials) }
+
+    before do
+      get '/api/v1/account/listings',
+      headers: landlord_headers
+    end
+
+    it 'should return a 200 response' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'should return landlord listings' do
+      expect(response_json["listings"].count).to eq 2
+    end
+
+    it 'should return landlord listings with lead' do
+      expect(response_json["listings"].first["lead"]).to eq 'vacant'
+    end
+
+    it 'should return landlord listings with lead' do
+      expect(response_json["listings"].first["scene"]).to eq 'indoor'
+    end
+  end
+end

--- a/spec/requests/api/v1/account/account_index_spec.rb
+++ b/spec/requests/api/v1/account/account_index_spec.rb
@@ -2,12 +2,10 @@ RSpec.describe "GET '/api/v1/account/listings" do
   let!(:landlord) { create(:user)}
   let!(:subscriber) { create(:user)}
 
-  let!(:listing_1) { create(:listing, lead: 'The first lead', scene: 'indoor', landlord_id: landlord.id) }
-  let!(:listing_2) { create(:listing, lead: 'The second lead', scene: 'indoor', landlord_id: subscriber.id) }
-  let!(:listing_3) { create(:listing, lead: 'The third lead', scene: 'indoor', landlord_id: subscriber.id) }
-  let!(:listing_4) { create(:listing, lead: 'The fourth lead', scene: 'outdoor', landlord_id: landlord.id) }
+  let!(:landlord_listings) { 2.times { create(:listing, lead: "The first lead", scene: "outdoor", landlord_id: landlord.id) } }
+  let!(:other_listings) { 2.times { create(:listing, landlord_id: subscriber.id) } }
 
-  describe 'landlord successfully get published listings' do
+  describe 'landlord successfully get their published listings' do
     let(:landlord_credentials) { landlord.create_new_auth_token }
     let(:landlord_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(landlord_credentials) }
 
@@ -28,7 +26,7 @@ RSpec.describe "GET '/api/v1/account/listings" do
       expect(response_json["listings"].first["lead"]).to eq 'The first lead'
     end
 
-    it 'should return landlord listings with lead' do
+    it 'should return landlord listings with scene' do
       expect(response_json["listings"].last["scene"]).to eq 'outdoor'
     end
   end


### PR DESCRIPTION
## [PT board URL]( https://www.pivotaltracker.com/story/show/174696726 )
### User Story
```
As a api
In order for landlords to see their listings
I would like to provide the ability to provide landlord listings
```
## Changes proposed in this pull request:
* account namespace with listings route
- listings controller with index action