### PR TITLE
Api provides the ability for a user(landlord) to see received bids

### DIFF
--- a/app/controllers/api/v1/account/listings_controller.rb
+++ b/app/controllers/api/v1/account/listings_controller.rb
@@ -11,7 +11,6 @@ def show
 
     render json: listing, serializer: ListingWithBidsShowSerializer
   rescue StandardError => e
-    binding.pry
     render json: { message: 'Unfortunately the listing could not be found' }, status: 422
   end
   

--- a/app/controllers/api/v1/account/listings_controller.rb
+++ b/app/controllers/api/v1/account/listings_controller.rb
@@ -5,4 +5,14 @@ class Api::V1::Account::ListingsController < ApplicationController
     listings = current_user.listings
     render json: listings, each_serializer: ListingIndexSerializer
   end
+
+def show
+    listing = current_user.listings.find(params[:id])
+
+    render json: listing, serializer: ListingWithBidsShowSerializer
+  rescue StandardError => e
+    binding.pry
+    render json: { message: 'Unfortunately the listing could not be found' }, status: 422
+  end
+  
 end

--- a/app/serializers/biddings_serializer.rb
+++ b/app/serializers/biddings_serializer.rb
@@ -1,0 +1,3 @@
+class BiddingsSerializer < ActiveModel::Serializer
+  attributes :id, :user_id, :bid
+end

--- a/app/serializers/listing_with_bids_show_serializer.rb
+++ b/app/serializers/listing_with_bids_show_serializer.rb
@@ -1,0 +1,18 @@
+class ListingWithBidsShowSerializer < ActiveModel::Serializer
+  include Rails.application.routes.url_helpers
+  attributes :id, :category, :lead, :scene, :description, :address, :price
+  attribute :images
+  has_many :biddings, serializer: BiddingsSerializer
+
+  def images
+    images_to_return = []
+    object.images.each do |image|
+      if Rails.env.test?
+        images_to_return << {url: rails_blob_url(image)}
+      else
+        images_to_return << {url: image.service_url(expires_in: 1.hour, disposition: "inline")}
+      end
+    end
+    images_to_return
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
       resources :biddings, only: [:create]
 
       namespace :account do
-        resources :listings, only: [:index], constraints: {format: 'json'}
+        resources :listings, only: [:index, :show], constraints: {format: 'json'}
       end
     end
   end  

--- a/spec/factories/biddings.rb
+++ b/spec/factories/biddings.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :bidding do
-    bid { 1.5 }
+    bid { 500 }
     association :listing, factory: :listing
   end
 end

--- a/spec/requests/api/v1/account/account_show_spec.rb
+++ b/spec/requests/api/v1/account/account_show_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'GET /api/v1/account/listings', type: :request do
     let(:landlord_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(landlord_credentials) }
 
     before do
-      get "/api/v1/account/listings/#{listing.id}"
+      get "/api/v1/account/listings/#{listing.id}", headers: landlord_headers
     end
 
     it 'respond with 200 status' do
@@ -29,6 +29,7 @@ RSpec.describe 'GET /api/v1/account/listings', type: :request do
     end
 
     it 'shows listing address' do
+      binding.pry
       expect(response_json['listing']['address']).to eq 'Vasagatan 1, 40530 Göteborg'
     end
 

--- a/spec/requests/api/v1/account/account_show_spec.rb
+++ b/spec/requests/api/v1/account/account_show_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe 'GET /api/v1/account/listings', type: :request do
+  let!(:landlord) { create(:user)}
+  let!(:subscriber) { create(:user)}
+
+  let!(:listing) do
+    create(
+      :listing,
+      :with_images,
+      category: 'Parking Spot',
+      lead: 'Big Space for big car',
+      scene: 'outdoor', address: 'Vasagatan 1, 40530 Göteborg',
+      description: 'Close to a kebab store',
+      price: 100,
+      landlord_id: landlord.id
+    )
+  end
+  let!(:bids) { 5.times { create(:bidding, listing_id: listing.id, user_id: subscriber.id)}}
+
+  describe 'successfully gets listing with bids' do
+    let(:landlord_credentials) { landlord.create_new_auth_token }
+    let(:landlord_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(landlord_credentials) }
+
+    before do
+      get "/api/v1/account/listings/#{listing.id}"
+    end
+
+    it 'respond with 200 status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'shows listing address' do
+      expect(response_json['listing']['address']).to eq 'Vasagatan 1, 40530 Göteborg'
+    end
+
+    it 'shows listing description' do
+      expect(response_json['listing']['description']).to eq 'Close to a kebab store'
+    end
+
+    it 'shows listing price' do
+      expect(response_json['listing']['price']).to eq 100
+    end
+
+    it 'shows bid received' do
+      expect(response_json["biddings"].count).to eq 5
+    end
+
+    it 'shows amount bidded' do
+      expect(response_json["biddings"]["bid"]).to eq 500
+    end
+  end
+
+  describe 'unsuccessfully gets listing' do
+    before do
+      get '/api/v1/listings/10'
+    end
+
+    it 'responds with 422 status' do
+      expect(response).to have_http_status 422
+    end
+
+    it 'responds with error message' do
+      expect(response_json['message']).to eq 'Unfortunately the listing could not be found'
+    end
+  end
+end

--- a/spec/requests/api/v1/account/account_show_spec.rb
+++ b/spec/requests/api/v1/account/account_show_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe 'GET /api/v1/account/listings', type: :request do
     end
 
     it 'shows listing address' do
-      binding.pry
       expect(response_json['listing']['address']).to eq 'Vasagatan 1, 40530 Göteborg'
     end
 
@@ -42,11 +41,11 @@ RSpec.describe 'GET /api/v1/account/listings', type: :request do
     end
 
     it 'shows bid received' do
-      expect(response_json["biddings"].count).to eq 5
+      expect(response_json["listing"]["biddings"].count).to eq 5
     end
 
     it 'shows amount bidded' do
-      expect(response_json["biddings"]["bid"]).to eq 500
+      expect(response_json["listing"]["biddings"].first["bid"]).to eq 500
     end
   end
 


### PR DESCRIPTION
## [PT board URL]( https://www.pivotaltracker.com/story/show/174705408 )
### User Story
```
As a api
In order for landlords to see their received bids
I would like to provide the ability to provide a show page for a listing with the bids
```
## Changes proposed in this pull request:
* show action for a current user's listings
* showing received bids tied to the listing
