### PR TITLE
Add Status to UseBidSerializer-Bug fix

### DIFF
--- a/app/serializers/user_bids_serializer.rb
+++ b/app/serializers/user_bids_serializer.rb
@@ -1,4 +1,4 @@
 class UserBidsSerializer < ActiveModel::Serializer
-  attributes :id, :bid
+  attributes :id, :bid, :status
   belongs_to :listing, serializer: ListingIndexSerializer
 end

--- a/spec/requests/api/v1/account/account_biddings_index_spec.rb
+++ b/spec/requests/api/v1/account/account_biddings_index_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "GET '/api/v1/account/biddings" do
   let!(:listings) { 2.times { create(:listing, landlord_id: landlord.id) }} 
 
   let!(:first_bid) { create(:bidding, listing_id: Listing.first.id, user_id: subscriber.id) }
-  let!(:second_bid) { create(:bidding, listing_id: Listing.last.id, user_id: subscriber.id) }
+  let!(:second_bid) { create(:bidding, listing_id: Listing.last.id, user_id: subscriber.id, status: "accepted") }
   let!(:other_bid) { create(:bidding, listing_id: Listing.first.id, user_id: other_user.id) }
 
   describe 'potential tenant successfully gets listings which they have bid on' do
@@ -32,6 +32,10 @@ RSpec.describe "GET '/api/v1/account/biddings" do
 
     it 'should return bid with an amount' do
       expect(response_json["biddings"].first["bid"]).to eq 500
+    end
+
+    it 'should return bid with the status' do
+      expect(response_json["biddings"].last["status"]).to eq "accepted"
     end
   end
 

--- a/spec/requests/api/v1/account/account_show_spec.rb
+++ b/spec/requests/api/v1/account/account_show_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe 'GET /api/v1/account/listings', type: :request do
       :with_images,
       category: 'Parking Spot',
       lead: 'Big Space for big car',
-      scene: 'outdoor', address: 'Vasagatan 1, 40530 Göteborg',
+      scene: 'outdoor',
+      address: 'Vasagatan 1, 40530 Göteborg',
       description: 'Close to a kebab store',
       price: 100,
       landlord_id: landlord.id
@@ -69,7 +70,8 @@ RSpec.describe 'GET /api/v1/account/listings', type: :request do
         :with_images,
         category: 'Parking Spot',
         lead: 'Big Space for big car',
-        scene: 'outdoor', address: 'Vasagatan 1, 40530 Göteborg',
+        scene: 'outdoor',
+        address: 'Vasagatan 1, 40530 Göteborg',
         description: 'Close to a kebab store',
         price: 100,
         landlord_id: landlord.id,
@@ -78,7 +80,8 @@ RSpec.describe 'GET /api/v1/account/listings', type: :request do
     end
 
     before do
-      get "/api/v1/account/listings/#{listing.id}", headers: landlord_headers
+      get "/api/v1/account/listings/#{listing.id}",
+       headers: landlord_headers
     end
 
     it 'respond with 200 status' do


### PR DESCRIPTION
## [PT board URL]( link )
### User Story
```
As an api
In order to make a better user experience 
I would like to display all bid's of a user with the  status in account page
```
## Changes proposed in this pull request:
* 
## What I have learned working on this feature:
* 
## Packages/Gems added
- 
## Screenshots (Client)